### PR TITLE
Decentralizing tournament

### DIFF
--- a/src/Plugin/Database/index.ts
+++ b/src/Plugin/Database/index.ts
@@ -101,9 +101,10 @@ export abstract class Database extends Plugin {
    * key stored in the user's statistics property mapping to the tournament's statistics. This is also the number of 
    * rankings.
    * @param tournamentKeyName 
-   * @param publicView
+   * @param offset - offset of the users
+   * @param limit - how many users to retrieve
    */
-  abstract getUsersInTournament(tournamentKeyName: string): Promise<Array<Database.User>>
+  abstract getUsersInTournament(tournamentKeyName: string, offset: number, limit: number): Promise<Array<Database.User>>
 
   /**
    * Returns true if the user info indicate the user is an admin

--- a/src/Plugin/Database/index.ts
+++ b/src/Plugin/Database/index.ts
@@ -48,8 +48,10 @@ export abstract class Database extends Plugin {
   /**
    * Returns a list of player stats based on their rankings from database. Used for Ladder Tournaments
    * @param tournament - The tournament to retrieve rankings for
+   * @param offset - offset ranking to start retreiving ranks from
+   * @param limit - number of players to retrieve. If -1, retrieve all players past offset rank
    */
-  abstract getRanks(tournament: Tournament.Ladder): Promise<Array<Ladder.PlayerStat>>
+  abstract getRanks(tournament: Tournament.Ladder, offset: number, limit: number): Promise<Array<Ladder.PlayerStat>>
 
   /**
    * Logs in a user, resolves with a JWT (JSON Web Token), rejects otherwise
@@ -62,7 +64,7 @@ export abstract class Database extends Plugin {
    * Registers a user, resolves when succesful, rejects otherwise
    * @param username - username to register with
    * @param password - the password for the user
-   * @param userData - any other kind of user data (not used)
+   * @param userData - any other kind of user data, (e.g email)
    */
   abstract registerUser(username: string, password: string, userData?: any): Promise<any>
 
@@ -96,7 +98,8 @@ export abstract class Database extends Plugin {
 
   /**
    * Gets all users with statistics in a tournament specified by the tournamentKeyName, which is a string that is the 
-   * key stored in the user's statistics property mapping to the tournament's statistics
+   * key stored in the user's statistics property mapping to the tournament's statistics. This is also the number of 
+   * rankings.
    * @param tournamentKeyName 
    * @param publicView
    */

--- a/src/Station/routes/api/dimensions/tournament/index.ts
+++ b/src/Station/routes/api/dimensions/tournament/index.ts
@@ -120,7 +120,15 @@ router.post('/:tournamentID/stop', requireAdmin, (req: Request, res: Response, n
  */
 router.get('/:tournamentID/ranks', async (req: Request, res: Response, next: NextFunction) => { 
   try {
-    let ranks = await req.data.tournament.getRankings();
+    let ranks = [];
+    let offset = req.query.offset ? req.query.offset : 0;
+    let limit = req.query.limit ? req.query.limit : -1;
+    if (req.data.tournament.configs.type === TournamentType.LADDER) {
+      ranks = await req.data.tournament.getRankings(offset, limit);
+    }
+    else {
+      ranks = await req.data.tournament.getRankings();
+    }
 
     res.json({error: null, ranks: ranks });
   }

--- a/src/SupportedPlugins/MongoDB/index.ts
+++ b/src/SupportedPlugins/MongoDB/index.ts
@@ -102,74 +102,90 @@ export class MongoDB extends Database {
     );
   }
 
-  public async getRanks(tournament: Tournament.Ladder): Promise<Array<Ladder.PlayerStat>> {
+  public async getRanks(tournament: Tournament.Ladder, offset: number, limit: number): Promise<Array<Ladder.PlayerStat>> {
     let keyname = tournament.getKeyName();
     if (tournament.configs.rankSystem === Tournament.RANK_SYSTEM.TRUESKILL) {
-      let rankData = await this.models.user.aggregate(
-        [
-          {
-            // select all users with stats in this tournament, implying they are still in the tourney
-            "$match":  {
-              ["statistics." + keyname]: {
-                "$exists": true
-              }
-            }
-          },
-          {
-            "$project": {
-              ["statistics." + keyname]: 1
-            }
-          },
-          {
-            "$addFields": {
-              "score": {
-                "$subtract": [
-                  `$statistics.${keyname}.rankState.rating.mu`,
-                  {
-                    "$multiply": [`$statistics.${keyname}.rankState.rating.sigma`, 3]
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "$sort": {
-              "score": -1
+      let agg: Array<Object> = [
+        {
+          // select all users with stats in this tournament, implying they are still in the tourney
+          "$match":  {
+            ["statistics." + keyname]: {
+              "$exists": true
             }
           }
-        ]);
+        },
+        {
+          "$project": {
+            ["statistics." + keyname]: 1
+          }
+        },
+        {
+          "$addFields": {
+            "score": {
+              "$subtract": [
+                `$statistics.${keyname}.rankState.rating.mu`,
+                {
+                  "$multiply": [`$statistics.${keyname}.rankState.rating.sigma`, 3]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$sort": {
+            "score": -1
+          }
+        },
+        {
+          "$skip": offset
+        }
+      ];
+      if (limit !== -1) {
+        agg.push({
+          "$limit": limit
+        });
+      }
+      let rankData = await this.models.user.aggregate(agg);
       return rankData.map((data) => {
         return data.statistics[keyname];
       });
 
     }
     else if (tournament.configs.rankSystem === Tournament.RANK_SYSTEM.ELO) {
-      let rankData = await this.models.user.aggregate(
-        [
-          {
-            // select all users with stats in this tournament, implying they are still in the tourney
-            "$match":  {
-              ["statistics." + keyname]: {
-                "$exists": true
-              }
-            }
-          },
-          {
-            "$project": {
-              ["statistics." + keyname]: 1
-            }
-          },
-          {
-            "$addFields": {
-              "score": `$statistics.${keyname}.rankState.rating.score`
-            }
-          },
-          {
-            "$sort": {
-              "score": -1
+      let agg: Array<Object> = [
+        {
+          // select all users with stats in this tournament, implying they are still in the tourney
+          "$match":  {
+            ["statistics." + keyname]: {
+              "$exists": true
             }
           }
-        ]);
+        },
+        {
+          "$project": {
+            ["statistics." + keyname]: 1
+          }
+        },
+        {
+          "$addFields": {
+            "score": `$statistics.${keyname}.rankState.rating.score`
+          }
+        },
+        {
+          "$sort": {
+            "score": -1
+          }
+        },
+        {
+          "$skip": offset
+        }
+      ];
+      if (limit !== -1) {
+        agg.push({
+          "$limit": limit
+        });
+      }
+      let rankData = await this.models.user.aggregate(agg);
       return rankData.map((data) => {
         return data.statistics[keyname];
       });

--- a/src/SupportedPlugins/MongoDB/index.ts
+++ b/src/SupportedPlugins/MongoDB/index.ts
@@ -1,14 +1,13 @@
 import mongoose from 'mongoose';
 import { Plugin } from '../../Plugin';
 import { Database } from '../../Plugin/Database';
-import { Dimension, DatabaseType, NanoID, DimensionConfigs } from '../../Dimension';
+import { Dimension, DatabaseType, NanoID } from '../../Dimension';
 import MatchSchemaCreator from './models/match';
 import { Match } from '../../Match';
 import { DeepPartial } from '../../utils/DeepPartial';
 import { pickMatch } from '../../Station/routes/api/dimensions/match';
 import bcrypt from 'bcryptjs';
 import UserSchemaCreator from './models/user';
-import configSchema from './models/configs';
 
 import { generateToken, verify } from '../../Plugin/Database/utils';
 import { Tournament } from '../../Tournament';
@@ -26,8 +25,7 @@ export class MongoDB extends Database {
 
   public models: MongoDB.Models = {
     user: null,
-    match: null,
-    configs: null
+    match: null
   }
 
   /** The MongoDB connection string used to connect to the database and read/write to it */
@@ -42,7 +40,6 @@ export class MongoDB extends Database {
     let userSchema = UserSchemaCreator();
     this.models.user = mongoose.model('User', userSchema);
 
-    this.models.configs = mongoose.model('Configs', configSchema);
   }
 
   /**
@@ -268,35 +265,6 @@ export class MongoDB extends Database {
     dimension.configs.backingDatabase = DatabaseType.MONGO;
     return;
   }
-
-  public async getTournamentConfigs(tournamentID: nanoid) {
-    return this.models.configs.findOne({ id: tournamentID }).then((config) => {
-      if (config) return config.toObject();
-      return null;
-    });
-  }
-  public async getDimensionConfigs(dimensionID: nanoid) {
-    return this.models.configs.findOne({ id: dimensionID }).then((config) => {
-      if (config) return config.toObject();
-      return null;
-    });
-
-  }
-  public async storeDimensionConfigs(dimensionID: nanoid, configs: DimensionConfigs) {
-    // perform upsert
-    return this.models.configs.findOneAndUpdate({id: dimensionID}, {id: dimensionID, configs: configs}, {upsert: true});
-  }
-  public async storeTournamentConfigs(
-    tournamentID: nanoid, 
-    configs: Tournament.TournamentConfigsBase,
-    status: Tournament.Status
-  ) {
-    return this.models.configs.findOneAndUpdate(
-      {id: tournamentID}, 
-      {id: tournamentID, configs: configs, status: status}, 
-      {upsert: true}
-    );
-  }
 }
 export module MongoDB {
 
@@ -322,7 +290,6 @@ export module MongoDB {
 
   export interface Models {
     user: mongoose.Model<mongoose.Document, {}>,
-    match: mongoose.Model<mongoose.Document, {}>,
-    configs: mongoose.Model<mongoose.Document, {}>
+    match: mongoose.Model<mongoose.Document, {}>
   }
 }

--- a/src/SupportedPlugins/MongoDB/index.ts
+++ b/src/SupportedPlugins/MongoDB/index.ts
@@ -269,9 +269,15 @@ export class MongoDB extends Database {
     return false;
   }
 
-  public async getUsersInTournament(tournamentKey: string) {
+  public async getUsersInTournament(tournamentKey: string, offset: number = 0, limit: number = -1) {
     let key = `statistics.${tournamentKey}`;
-    return this.models.user.find({ [key]: {$exists: true}}).then((users) => {
+    if (limit == -1) {
+      limit = 0;
+    }
+    else if (limit == 0) {
+      return [];
+    }
+    return this.models.user.find({ [key]: {$exists: true} }).skip(offset).limit(limit).then((users) => {
       let mapped = users.map(user => user.toObject());
       return mapped;
     });

--- a/src/Tournament/Elimination/index.ts
+++ b/src/Tournament/Elimination/index.ts
@@ -13,13 +13,14 @@ import { RankSystem } from "../RankSystem";
 
 /**
  * The Elimination Tournament Class. Runs a single-elimination tournament.
+ * 
+ * Meant for single instance use only
  */
 export class Elimination extends Tournament {
   configs: Tournament.TournamentConfigs<EliminationConfigs> = {
     defaultMatchConfigs: {},
     type: Tournament.Type.ELIMINATION,
     rankSystem: null,
-    addDatabasePlayers: false,
     rankSystemConfigs: null,
     tournamentConfigs: {
       times: 1,

--- a/src/Tournament/Ladder/index.ts
+++ b/src/Tournament/Ladder/index.ts
@@ -225,7 +225,8 @@ export class Ladder extends Tournament {
     let playerStatsList: Array<Ladder.PlayerStat> = [];
     let userList: Array<Database.User> = [];
     if (this.dimension.hasDatabase()) {
-      userList = (await this.dimension.databasePlugin.getUsersInTournament(this.getKeyName()));
+      // get every user
+      userList = (await this.dimension.databasePlugin.getUsersInTournament(this.getKeyName(), 0, -1));
       playerStatsList = userList.map((user) => user.statistics[this.getKeyName()]);
       
       // add anonymous users
@@ -703,6 +704,7 @@ export class Ladder extends Tournament {
    * @param playerID 
    */
   async internalRemovePlayer(playerID: nanoid) {
+    // TODO: we sometimes do a redudant call to get player stats when we really just need to check for existence
     if (this.getPlayerStat(playerID)) {
       
       this.playersToRemove.add(playerID);

--- a/src/Tournament/Ladder/index.ts
+++ b/src/Tournament/Ladder/index.ts
@@ -51,11 +51,6 @@ export class Ladder extends Tournament {
   };
 
   /**
-   * Set of player IDs of players to remove
-   */
-  private playersToRemove: Set<nanoid> = new Set();
-
-  /**
    * ELO System used in this tournament
    */
   private elo: ELOSystem;

--- a/src/Tournament/Ladder/index.ts
+++ b/src/Tournament/Ladder/index.ts
@@ -580,6 +580,7 @@ export class Ladder extends Tournament {
    * If a {@link Ladder.Configs.matchMake | matchMake} function is provided, that will be used instead of the default.
    */
   private async schedule() {
+    // TODO: Slide window instead for dealing with rankings. good buffer size might be max 1k players ~ 10mb
     let rankings = await this.getRankings(0, -1);
     if (this.configs.tournamentConfigs.matchMake) {
       let newMatches = this.configs.tournamentConfigs.matchMake(rankings);

--- a/src/Tournament/Ladder/index.ts
+++ b/src/Tournament/Ladder/index.ts
@@ -584,10 +584,10 @@ export class Ladder extends Tournament {
     }
 
     // runs a round of scheduling
-    // for every player, we schedule a match
+    // for every not disabled player, we schedule a match
     // TODO: For scalability, getrankings should handle just a subset at a time in order to not load too much at once.
     
-    let sortedPlayers = rankings.map((p) => p.player);
+    let sortedPlayers = rankings.map((p) => p.player).filter((p) => !p.disabled);
     let newQueue = [];
     rankings.forEach((playerStat, rank) => {
       let player = playerStat.player;
@@ -728,7 +728,7 @@ export class Ladder extends Tournament {
             `%-30s | %-14s | %-15s | %-18s | %-8s`.underline, 'Name', 'ID', 'Score=(μ - 3σ)', 'Mu: μ, Sigma: σ', 'Matches'));
           ranks.forEach((info) => {
             console.log(sprintf(
-              `%-30s`.blue+ ` | %-14s | ` + `%-15s`.green + ` | ` + `μ=%-6s, σ=%-6s`.yellow +` | %-8s`, info.player.tournamentID.name, info.player.tournamentID.id, (info.rankState.rating.mu - info.rankState.rating.sigma * 3).toFixed(7), info.rankState.rating.mu.toFixed(3), info.rankState.rating.sigma.toFixed(3), info.matchesPlayed));
+              `%-30s`.blue+ ` | %-14s | ` + `%-15s`.green + ` | ` + `μ=%-6s, σ=%-6s`.yellow +` | %-8s`, info.player.tournamentID.name + (info.player.disabled ? ' X': ''), info.player.tournamentID.id, (info.rankState.rating.mu - info.rankState.rating.sigma * 3).toFixed(7), info.rankState.rating.mu.toFixed(3), info.rankState.rating.sigma.toFixed(3), info.matchesPlayed));
           });
           break;
         case RankSystem.ELO:

--- a/src/Tournament/RankSystem/index.ts
+++ b/src/Tournament/RankSystem/index.ts
@@ -77,8 +77,7 @@ export namespace RankSystem {
     /** The current rank state of a player */
     export interface RankState {
       /** The ELO Rating */
-      rating: ELORating,
-      toJSON?: Function
+      rating: ELORating
     }
   }
 
@@ -108,9 +107,7 @@ export namespace RankSystem {
        * 
        * rating.mu, rating.sigma returns the mu and sigma of the rank. 
        */
-      rating: Rating,
-      /** Function to return some internal data of rating when using API */
-      toJSON?: Function
+      rating: Rating
     }
   }
 }

--- a/src/Tournament/RoundRobin/index.ts
+++ b/src/Tournament/RoundRobin/index.ts
@@ -12,14 +12,13 @@ import { Dimension, NanoID } from "../../Dimension";
 /**
  * The Round Robin Tournament Class
  * 
- * Only supports two agent matches at the moment
+ * Only supports two agent matches at the moment and is meant for single instance use only 
  */
 export class RoundRobin extends Tournament {
   configs: Tournament.TournamentConfigs<Tournament.RoundRobin.Configs> = {
     defaultMatchConfigs: {},
     type: Tournament.Type.ROUND_ROBIN,
     rankSystem: null,
-    addDatabasePlayers: false,
     rankSystemConfigs: null,
     tournamentConfigs: {
       times: 2,
@@ -330,7 +329,7 @@ export class RoundRobin extends Tournament {
       console.log('Total Matches: ' + this.state.statistics.totalMatches);
       let ranks = this.getRankings();
       switch(this.configs.rankSystem) {
-        case RankSystem.WINS:
+        case Tournament.RankSystem.WINS:
           console.log(sprintf(
             `%-20s | %-8s | %-15s | %-6s | %-6s | %-8s | %-8s`.underline, 'Name', 'ID', 'Score', 'Wins', 'Ties', 'Losses', 'Matches'));
           ranks.forEach((info) => {

--- a/src/Tournament/index.ts
+++ b/src/Tournament/index.ts
@@ -323,7 +323,10 @@ export abstract class Tournament {
    * @param playerID - ID of the player to remove
    */
   public async removePlayer(playerID: nanoid) {
-    if (this.competitors.delete(playerID)) {
+    let playerStat = this.getPlayerStat(playerID);
+    if (playerStat) {
+      this.competitors.delete(playerID);
+      this.anonymousCompetitors.delete(playerID);
       await this.internalRemovePlayer(playerID);
     }
     else {

--- a/src/Tournament/index.ts
+++ b/src/Tournament/index.ts
@@ -155,7 +155,6 @@ export abstract class Tournament {
     if (!tournamentConfigs.name && dimension.hasDatabase()) {
       this.log.error(`A name has to be specified for a tournament otherwise tournament player data will not be reused across runs of the tournament`)
     }
-  
   }
 
   /**
@@ -316,9 +315,13 @@ export abstract class Tournament {
   public abstract async resume();
 
   /**
-   * Retrieve some form of rankings from the tournament's current state
+   * Retrieve some form of rankings from the tournament's current state. The params offset and limit only apply to 
+   * {@link Tournament.Ladder | Ladder Tournaments}, used for scaling purposes.
+   * 
+   * @param offset - the starting ranking to retrieve from
+   * @param limit - the number of rankings to retrieve
    */
-  public abstract getRankings(): any;
+  public abstract getRankings(offset?: number, limit?: number): any;
 
   /**
    * Update function that is called whenever an existing player is updated
@@ -600,7 +603,7 @@ export module Tournament {
    * Internally used type.
    */
   export interface TournamentConfigs<ConfigType> extends TournamentConfigsBase {
-    tournamentConfigs: ConfigType    
+    tournamentConfigs: ConfigType
     rankSystemConfigs: any
   }
 

--- a/src/Tournament/index.ts
+++ b/src/Tournament/index.ts
@@ -31,11 +31,6 @@ export class Player {
    */
   public anonymous: boolean = true;
 
-  /**
-   * Number of matches this player is involved in at the moment
-   */
-  public activeMatchCount: number = 0;
-
   /** Associated username if there is one */
   public username: string = undefined;
 

--- a/src/Tournament/index.ts
+++ b/src/Tournament/index.ts
@@ -172,6 +172,10 @@ export abstract class Tournament {
       if (playerStat) {
         // bot has stats in tournament already
         let player = playerStat.player
+        
+        // undisable the player
+        player.disabled = false;
+        
         let oldname = player.tournamentID.name;
         let oldfile = player.file;
         // remove the oldfile


### PR DESCRIPTION
New:
- Decentralized tournament. Only stores anonymous players locally, all others are always pulled from DB if it exists. If there isn't a DB, they should be stored in the competitors map.
- Improvements to player removal and made code a lot more concise
- Enforcing the offset and limit pattern for most DB requests that return lists of some sort
- Improved error handling and explanations of what's going on when a match fails to run or results fail to be parsed.
- Player has a disabled tag now, used for tagging players to be removed to prevent them from being run in any matches. Note that the scheduler still sends disabled players to the `matchMake` option. This tag shows up on console as well.

Fixes:
- Fixed bug in mongodb plugin where admin user was not auto created