### PR TITLE
add language specific options and tests for using different images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
           name: Pull standard images for Dimensions
           command: docker pull docker.io/stonezt2000/dimensions_langs
       - run:
+          name: Pull other images used for testing
+          command: ./pull_all_test_docker_images.sh
+      - run:
           name: install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:

--- a/pull_all_test_docker_images.sh
+++ b/pull_all_test_docker_images.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+docker pull python:3.8.5-slim-buster
+docker pull golang
+docker pull openjdk
+docker pull gcc
+docker pull php

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -119,6 +119,7 @@ export class Match {
     engineOptions: {},
     secureMode: false,
     agentOptions: deepCopy(Agent.OptionDefaults),
+    languageSpecificAgentOptions: {},
     storeReplay: true,
     storeReplayDirectory: 'replays',
     storeErrorLogs: true,
@@ -269,7 +270,8 @@ export class Match {
       // Initialize agents with agent files
       this.agents = Agent.generateAgents(
         this.agentFiles,
-        this.configs.agentOptions
+        this.configs.agentOptions,
+        this.configs.languageSpecificAgentOptions
       );
       this.agents.forEach((agent) => {
         this.idToAgentsMap.set(agent.id, agent);
@@ -777,6 +779,12 @@ export namespace Match {
      * Default Agent options to use for all agents in a match. Commonly used for setting resource use boundaries
      */
     agentOptions: DeepPartial<Agent.Options>;
+
+    /**
+     * Agent options to override with depending on extension of file
+     * @default `{}` - an empty object
+     */
+    languageSpecificAgentOptions: Agent.LanguageSpecificOptions;
 
     /**
      * Whether or not to store a replay file if match results indicate a replay file was stored

--- a/templates/docker/Dockerfile
+++ b/templates/docker/Dockerfile
@@ -1,3 +1,9 @@
+#
+# This is a Docker file that installs every language necessary to use this for every agent regardless of language
+# provided the language is supported by Dimensions. This is also used to build the standard image used for testing on 
+# circleci
+#
+
 FROM alpine:3.11
 
 RUN apk update

--- a/templates/docker/languageSpecific/Dockerfile
+++ b/templates/docker/languageSpecific/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.11
+
+RUN apk update
+
+RUN apk add --no-cache python3

--- a/tests/core/engine/04-engine.language.spec.ts
+++ b/tests/core/engine/04-engine.language.spec.ts
@@ -49,6 +49,11 @@ describe('Testing MatchEngine Multi Language Support', () => {
                 '.py': ['python3'],
               },
             },
+            languageSpecificAgentOptions: {
+              '.py': {
+                image: 'python:3.8.5-slim-buster',
+              },
+            },
           });
           expect(results.scores).to.eql({ '0': 0, '1': 9 });
         });
@@ -69,6 +74,11 @@ describe('Testing MatchEngine Multi Language Support', () => {
           const results = await d.runMatch([bots.java, bots.js], {
             bestOf: 9,
             secureMode: bool,
+            languageSpecificAgentOptions: {
+              '.go': {
+                image: 'openjdk',
+              },
+            },
           });
           expect(results.scores).to.eql({ '0': 0, '1': 9 });
         });
@@ -89,6 +99,11 @@ describe('Testing MatchEngine Multi Language Support', () => {
           const results = await d.runMatch([bots.c, bots.js], {
             bestOf: 9,
             secureMode: bool,
+            languageSpecificAgentOptions: {
+              '.go': {
+                image: 'gcc',
+              },
+            },
           });
           expect(results.scores).to.eql({ '0': 0, '1': 9 });
         });
@@ -99,6 +114,11 @@ describe('Testing MatchEngine Multi Language Support', () => {
           const results = await d.runMatch([bots.go, bots.js], {
             bestOf: 9,
             secureMode: bool,
+            languageSpecificAgentOptions: {
+              '.go': {
+                image: 'golang',
+              },
+            },
           });
           expect(results.scores).to.eql({ '0': 0, '1': 9 });
         });
@@ -109,6 +129,11 @@ describe('Testing MatchEngine Multi Language Support', () => {
           const results = await d.runMatch([bots.php, bots.js], {
             bestOf: 9,
             secureMode: bool,
+            languageSpecificAgentOptions: {
+              '.go': {
+                image: 'php',
+              },
+            },
           });
           expect(results.scores).to.eql({ '0': 0, '1': 9 });
         });


### PR DESCRIPTION
New:
 - New configuration for matches: languageSpecificAgentOptions, which takes a object mapping language extensions to agent options to override with. Tested its capability to allow different docker images to be used for each language (reducing a lot of overhead)
- Added a new file to pull all images used for testing

Notes:
- Should use smaller alpine images with just tools for that language and bash for testing
- Future, provide template docker images with a lot of prepackaged stuff e.g common js, python, golang packages