### PR TITLE
Store agent versions and better type safety with agents, bug fixes

### DIFF
--- a/src/Dimension/index.ts
+++ b/src/Dimension/index.ts
@@ -14,6 +14,8 @@ import { Plugin } from '../Plugin';
 import { Database } from '../Plugin/Database';
 import { Storage } from '../Plugin/Storage';
 import { existsSync, mkdirSync } from 'fs';
+import { Agent } from '../Agent';
+import { AgentClassTypeGuards } from '../utils/TypeGuards';
 
 /**
  * Some standard database type strings
@@ -268,8 +270,8 @@ export class Dimension {
    */
   public async createMatch(
     files:
-      | Array<string>
-      | Array<{ file: string; name: string; botkey?: string }>,
+      | Agent.GenerationMetaData_FilesOnly
+      | Agent.GenerationMetaData_CreateMatch,
     configs?: DeepPartial<Match.Configs>
   ): Promise<Match> {
     if (!files.length) {
@@ -282,15 +284,10 @@ export class Dimension {
 
     // create new match
     let match: Match;
-    if (typeof files[0] === 'string') {
-      match = new Match(this.design, <Array<string>>files, matchConfigs, this);
+    if (AgentClassTypeGuards.isGenerationMetaData_FilesOnly(files)) {
+      match = new Match(this.design, files, matchConfigs, this);
     } else {
-      match = new Match(
-        this.design,
-        <Array<{ file: string; name: string; botkey?: string }>>files,
-        matchConfigs,
-        this
-      );
+      match = new Match(this.design, files, matchConfigs, this);
     }
     this.statistics.matchesCreated++;
 
@@ -317,8 +314,8 @@ export class Dimension {
    */
   public async runMatch(
     files:
-      | Array<string>
-      | Array<{ file: string; name: string; botkey?: string }>,
+      | Agent.GenerationMetaData_FilesOnly
+      | Agent.GenerationMetaData_CreateMatch,
     configs?: DeepPartial<Match.Configs>
   ): Promise<any> {
     const match = await this.createMatch(files, configs);

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -173,10 +173,11 @@ export class Match {
    */
   constructor(
     public design: Design,
-    public agentFiles:
-      | Array<string>
-      | Array<{ file: string; name: string; botkey?: string }> // used in createMatch
-      | Array<{ file: string; tournamentID: Tournament.ID; botkey?: string }>, // used by tournaments
+    /**
+     * agent meta data regarding files, ids, etc.
+     */
+    public agentFiles: /** array of file paths to agents */
+    Agent.GenerationMetaData,
     configs: DeepPartial<Match.Configs> = {},
     private dimension: Dimension
   ) {

--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -308,8 +308,7 @@ export class Match {
       this.matchStatus = Match.Status.READY;
       return true;
     } catch (err) {
-      // first handle log files in case they might hold relevant install / compile time logs
-      this.handleLogFiles();
+      await this.handleLogFiles();
       // kill processes and clean up and then throw the error
       await this.killAndCleanUp();
       throw err;
@@ -419,8 +418,7 @@ export class Match {
             );
           }
         }
-        // TODO: possible race condition if we dont wait for log files to upload
-        this.handleLogFiles();
+        await this.handleLogFiles();
         this.finishDate = new Date();
         resolve(this.results);
       } catch (error) {

--- a/src/Station/routes/api/dimensions/match/agent/index.ts
+++ b/src/Station/routes/api/dimensions/match/agent/index.ts
@@ -33,20 +33,8 @@ export const getAgent = (
  */
 export const pickAgent = (
   agent: Agent
-): Pick<
-  Agent,
-  'creationDate' | 'id' | 'name' | 'src' | 'status' | 'tournamentID' | 'logkey'
-> => {
-  const picked = pick(
-    agent,
-    'creationDate',
-    'id',
-    'name',
-    'src',
-    'status',
-    'tournamentID',
-    'logkey'
-  );
+): Pick<Agent, 'id' | 'name' | 'tournamentID' | 'logkey' | 'version'> => {
+  const picked = pick(agent, 'id', 'name', 'tournamentID', 'logkey', 'version');
   return picked;
 };
 

--- a/src/SupportedPlugins/FileSystemStorage/index.ts
+++ b/src/SupportedPlugins/FileSystemStorage/index.ts
@@ -97,7 +97,7 @@ export class FileSystemStorage extends Storage {
     await this.writeFileFromBucket(key, destination);
     // store in cache
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const cachedPath = this.lruFileCache.add(key, destination);
+    const cachedPath = await this.lruFileCache.add(key, destination);
     this.log.system(`${key} cached to ${cachedPath}`);
     return destination;
   }

--- a/src/SupportedPlugins/GCloudStorage/index.ts
+++ b/src/SupportedPlugins/GCloudStorage/index.ts
@@ -114,7 +114,7 @@ export class GCloudStorage extends DStorage {
         .pipe(fs.createWriteStream(destination));
       ws.on('close', () => {
         // store in cache
-        const cachedPath = this.lruFileCache.add(key, destination);
+        const cachedPath = await this.lruFileCache.add(key, destination);
         this.log.system(
           `writing from bucket ${key} -> ${destination}; cached to ${cachedPath}`
         );

--- a/src/SupportedPlugins/GCloudStorage/index.ts
+++ b/src/SupportedPlugins/GCloudStorage/index.ts
@@ -112,7 +112,7 @@ export class GCloudStorage extends DStorage {
       const ws = file
         .createReadStream()
         .pipe(fs.createWriteStream(destination));
-      ws.on('close', () => {
+      ws.on('close', async () => {
         // store in cache
         const cachedPath = await this.lruFileCache.add(key, destination);
         this.log.system(

--- a/src/SupportedPlugins/MongoDB/index.ts
+++ b/src/SupportedPlugins/MongoDB/index.ts
@@ -13,8 +13,6 @@ import { generateToken, verify } from '../../Plugin/Database/utils';
 import { Tournament } from '../../Tournament';
 import { pick } from '../../utils';
 import { nanoid } from '../..';
-import { Ladder } from '../../Tournament/Ladder';
-import { TournamentError } from '../../DimensionError';
 import TournamentConfigSchema from './models/tournamentConfig';
 import { TournamentStatus } from '../../Tournament/TournamentStatus';
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/src/Tournament/index.ts
+++ b/src/Tournament/index.ts
@@ -523,18 +523,17 @@ export abstract class Tournament extends EventEmitter {
     }
     matchConfigs.agentSpecificOptions = agentSpecificOptions;
 
-    const filesAndNamesAndIDs: Array<{
-      file: string;
-      tournamentID: Tournament.ID;
-      botkey?: string;
-    }> = players.map((player) => {
-      // if player has a botkey, use that, otherwise use whats in player.file
-      return {
-        file: player.file,
-        tournamentID: player.tournamentID,
-        botkey: player.botkey,
-      };
-    });
+    const filesAndNamesAndIDs: Agent.GenerationMetaData_Tournament = players.map(
+      (player) => {
+        // if player has a botkey, use that, otherwise use whats in player.file
+        return {
+          file: player.file,
+          tournamentID: player.tournamentID,
+          botkey: player.botkey,
+          version: player.version,
+        };
+      }
+    );
     const match = new Match(
       this.design,
       filesAndNamesAndIDs,

--- a/src/utils/LRUFileCache.ts
+++ b/src/utils/LRUFileCache.ts
@@ -2,6 +2,7 @@ import fs, { copyFileSync, mkdirSync } from 'fs';
 import constants from 'constants';
 import { removeDirectory } from './System';
 import path from 'path';
+import { noop } from '.';
 /**
  * A variant of the LRU cache where this cache stores mappings from keys to file paths. This throws out least recently
  * used items when adding a new file path to cache. Thrown out items are removed from cache and the file it pointed to
@@ -57,7 +58,7 @@ export default class LRUFileCache {
           path.dirname(
             this.getCachedFilePath(this.queueTail.filepath, this.queueTail.key)
           )
-        )
+        ).catch(noop)
       );
       this.cache.delete(this.queueTail.key);
       if (newtail) {

--- a/src/utils/TypeGuards.ts
+++ b/src/utils/TypeGuards.ts
@@ -1,5 +1,26 @@
 import { ChildProcess } from 'child_process';
+import { Agent } from '../Agent';
 
 export const isChildProcess = (p: unknown): p is ChildProcess => {
   return p ? p.constructor.name === 'ChildProcess' : false;
 };
+
+export class AgentClassTypeGuards {
+  static isGenerationMetaData_FilesOnly(
+    p: unknown
+  ): p is Agent.GenerationMetaData_FilesOnly {
+    return typeof p[0] === 'string';
+  }
+
+  static isGenerationMetaData_CreateMatch(
+    p: unknown
+  ): p is Agent.GenerationMetaData_CreateMatch {
+    return p[0].name !== undefined;
+  }
+
+  static isGenerationMetaData_Tournament(
+    p: unknown
+  ): p is Agent.GenerationMetaData_Tournament {
+    return p[0].tournamentID !== undefined;
+  }
+}

--- a/tests/core/storage/01-storage.tourney.spec.ts
+++ b/tests/core/storage/01-storage.tourney.spec.ts
@@ -261,27 +261,18 @@ describe('Testing Storage with Tournament Singletons (no distribution)', () => {
               for (const match of matches) {
                 expect(
                   fs.existsSync(
-                    path.join(
-                      fsstore.bucketPath,
-                      `errorlogs/match_${match.id}/agent_0.log`
-                    )
+                    path.join(fsstore.bucketPath, `${match.agents[0].logkey}`)
                   )
                 ).to.equal(true, 'error log should exist');
                 expect(
                   fs.existsSync(
-                    path.join(
-                      fsstore.bucketPath,
-                      `errorlogs/match_${match.id}/agent_1.log`
-                    )
+                    path.join(fsstore.bucketPath, `${match.agents[1].logkey}`)
                   )
                 ).to.equal(true, 'error log should exist');
 
                 expect(
                   fs.existsSync(
-                    path.join(
-                      fsstore.bucketPath,
-                      `replaydir/${match.id}.replay`
-                    )
+                    path.join(fsstore.bucketPath, `${match.replayFileKey}`)
                   )
                 ).to.equal(true, 'replay file should exist');
               }


### PR DESCRIPTION
New:
- Agent generation parameters are now better typed and have associated type guards
- version is stored in agent meta data stored into mongo by default, stripped off creationDate, status, ...

Fixes:
- Fixed race condition causing logkey not to be stored into db
- Probably fixed race condition causing storage plugins to not cache in time due to async call. fixes one of the tests
- fixed case where lrufilecache has unhandledpromises when it comes to deleting the same directory/file. ignored all those errors with catch(noop)