### PR TITLE
Fix bugs with match initialize and store match regardless of error

### DIFF
--- a/src/Match/index.ts
+++ b/src/Match/index.ts
@@ -11,6 +11,9 @@ import {
   MatchError,
   NotSupportedError,
   MatchReplayFileError,
+  AgentError,
+  AgentCompileError,
+  AgentInstallError,
 } from '../DimensionError';
 import { Tournament } from '../Tournament';
 
@@ -96,8 +99,9 @@ export class Match {
 
   /**
    * The results field meant to store any results retrieved with {@link Design.getResults}
+   * @default `null`
    */
-  public results: any;
+  public results: any = null;
 
   /**
    * The current match status
@@ -311,6 +315,17 @@ export class Match {
       await this.handleLogFiles();
       // kill processes and clean up and then throw the error
       await this.killAndCleanUp();
+
+      if (err instanceof AgentError) {
+        if (
+          err instanceof AgentCompileError ||
+          err instanceof AgentInstallError
+        ) {
+          // mark agents with compile or install error as having crashed
+          // console.log(err, err.agentID);
+          this.agents[err.agentID].status = Agent.Status.CRASHED;
+        }
+      }
       throw err;
     }
   }

--- a/src/Station/routes/api/dimensions/match/agent/index.ts
+++ b/src/Station/routes/api/dimensions/match/agent/index.ts
@@ -33,8 +33,19 @@ export const getAgent = (
  */
 export const pickAgent = (
   agent: Agent
-): Pick<Agent, 'id' | 'name' | 'tournamentID' | 'logkey' | 'version'> => {
-  const picked = pick(agent, 'id', 'name', 'tournamentID', 'logkey', 'version');
+): Pick<
+  Agent,
+  'id' | 'name' | 'tournamentID' | 'logkey' | 'version' | 'status'
+> => {
+  const picked = pick(
+    agent,
+    'id',
+    'name',
+    'tournamentID',
+    'logkey',
+    'version',
+    'status'
+  );
   return picked;
 };
 

--- a/src/Tournament/index.ts
+++ b/src/Tournament/index.ts
@@ -587,13 +587,6 @@ export abstract class Tournament extends EventEmitter {
       // Get results
       const results = await match.run();
 
-      // if database plugin is active and saveTournamentMatches is set to true, store match
-      if (this.dimension.hasDatabase()) {
-        if (this.dimension.databasePlugin.configs.saveTournamentMatches) {
-          this.dimension.databasePlugin.storeMatch(match, this.id);
-        }
-      }
-
       // remove the match from the active matches list
       this.matches.delete(match.id);
 
@@ -606,6 +599,14 @@ export abstract class Tournament extends EventEmitter {
         err,
         match,
       };
+    } finally {
+      // regardless of error or not ensure match is stored
+      // if database plugin is active and saveTournamentMatches is set to true, store match
+      if (this.dimension.hasDatabase()) {
+        if (this.dimension.databasePlugin.configs.saveTournamentMatches) {
+          this.dimension.databasePlugin.storeMatch(match, this.id);
+        }
+      }
     }
   }
 

--- a/tests/core/engine/01-engine.spec.ts
+++ b/tests/core/engine/01-engine.spec.ts
@@ -354,32 +354,50 @@ describe('Testing MatchEngine Core', () => {
 
   describe('Test compilation step', () => {
     for (const bool of tf) {
-      it(`should throw error for bot going over compile time limit; secureMode: ${bool}`, async () => {
-        await expect(
-          d.createMatch([bots.java, bots.js], {
+      it(`should throw error for bot going over compile time limit and mark agent as crashed; secureMode: ${bool}`, async () => {
+        const match = new Match(
+          d.design,
+          [bots.java, bots.js],
+          {
             bestOf: 11,
+            loggingLevel: 0,
             secureMode: bool,
             agentOptions: {
               maxCompileTime: 100,
             },
-          })
-        ).to.be.rejectedWith(AgentCompileTimeoutError);
+          },
+          d
+        );
+        await expect(match.initialize()).to.be.rejectedWith(
+          AgentCompileTimeoutError
+        );
+        expect(match.agents[0].status).to.equal(Agent.Status.CRASHED);
+        expect(match.agents[1].status).to.equal(Agent.Status.KILLED);
       });
     }
   });
 
   describe('Test install step', () => {
     for (const bool of tf) {
-      it(`should throw error for bot going over install time limit; secureMode: ${bool}`, async () => {
-        await expect(
-          d.createMatch([jsWithSlowInstall, bots.js], {
+      it(`should throw error for bot going over install time limit and mark agent as crashed; secureMode: ${bool}`, async () => {
+        const match = new Match(
+          d.design,
+          [jsWithSlowInstall, bots.js],
+          {
             bestOf: 11,
+            loggingLevel: 0,
             secureMode: bool,
             agentOptions: {
               maxInstallTime: 100,
             },
-          })
-        ).to.be.rejectedWith(AgentInstallTimeoutError);
+          },
+          d
+        );
+        await expect(match.initialize()).to.be.rejectedWith(
+          AgentInstallTimeoutError
+        );
+        expect(match.agents[0].status).to.equal(Agent.Status.CRASHED);
+        expect(match.agents[1].status).to.equal(Agent.Status.KILLED);
       });
     }
   });

--- a/tests/core/match/01-match.spec.ts
+++ b/tests/core/match/01-match.spec.ts
@@ -38,6 +38,7 @@ describe('Testing Match Core', () => {
       const match = await d.createMatch(botList);
       const deeped = stripFunctions(deepCopy(d.configs.defaultMatchConfigs));
       expect(match.configs).to.containSubset(deeped);
+      expect(match.results).to.equal(null);
     });
   });
 


### PR DESCRIPTION
New:
- Agent status is actually meaningful. Marked crashed if agent entered a compile or install error (and people can check error logs)
- Match is stored into DB regardless of error during tourney running so agents that enter compile/install errors will have that error propagated into error logs and a reference to those error logs and crashed agents stored in db

Changes:
- match results field is now default `null` to avoid confusion. If its null and stored in DB, indicates likely agent crashed or something.

Fixes:
- bug where tournament would stall on promise due to unresolved promise as bot was disabled at initialization and didnt reach var unlock stage