### PR TITLE
Fix a test and switch order of actions in match.update function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dimensions-ai",
-  "version": "4.6.14",
+  "version": "4.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dimensions-ai",
-      "version": "4.6.14",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/datastore": "^6.1.0",
@@ -7777,25 +7777,12 @@
       "dev": true
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
       "requires": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "bluebird": {
@@ -10331,17 +10318,6 @@
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
-        }
       }
     },
     "mongoose": {
@@ -11594,6 +11570,16 @@
         "readable-stream": "^3.1.1"
       },
       "dependencies": {
+        "bl": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",

--- a/tests/core/match/01-match.spec.ts
+++ b/tests/core/match/01-match.spec.ts
@@ -65,7 +65,7 @@ describe('Testing Match Core', () => {
   const testRunStopMatch = async (match: Match) => {
     expect(match.matchStatus).to.equal(Match.Status.READY);
     match.run().catch(noop);
-    return new Promise((res, rej) => {
+    return new Promise<void>((res, rej) => {
       setTimeout(async () => {
         try {
           expect(match.matchStatus).to.equal(Match.Status.RUNNING);
@@ -105,7 +105,7 @@ describe('Testing Match Core', () => {
       match.run().catch(noop);
 
       const timer = () => {
-        return new Promise((res, rej) => {
+        return new Promise<void>((res, rej) => {
           setTimeout(async () => {
             try {
               expect(match.matchStatus).to.equal(Match.Status.RUNNING);


### PR DESCRIPTION
Fixes a bug where the first turn is always empty and engine will choose not to receive any commands as none of the agents are reset yet. This causes inconsistencies between what is expected to happen when using match.step as opposed to match.run (which uses match.update)