### PR TITLE
Fix EPERM on Windows and fix Tournament freeze with agent timeout

### DIFF
--- a/src/Agent/index.ts
+++ b/src/Agent/index.ts
@@ -775,6 +775,7 @@ export class Agent extends EventEmitter {
     this.status = Agent.Status.KILLED;
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
+      this.errorLogWriteStream?.close();
       if (this.options.secureMode) {
         if (this.container) {
           try {
@@ -814,6 +815,8 @@ export class Agent extends EventEmitter {
                 resolve();
               }
             });
+          } else {
+            resolve();
           }
         } else {
           resolve();

--- a/src/MatchEngine/index.ts
+++ b/src/MatchEngine/index.ts
@@ -287,7 +287,9 @@ export class MatchEngine {
         // store logs below limit only
         if (agent._logsize < agent.options.logLimit) {
           agent._logsize += data.length;
-          errorLogWriteStream.write(`${data}`);
+          if (!errorLogWriteStream.destroyed) {
+            errorLogWriteStream.write(`${data}`);
+          }
         } else {
           if (agent._trimmed === false) {
             agent._trimmed = true;


### PR DESCRIPTION
## Tournament freeze on Timeout
If an agent timeout in a tournament, then its process is killed before the end of the match.
When `Agent._terminate()` is called, the process doesn't exist (`this.process` is never set to null).
So the promise is never solved and the tournament is stuck.

## EPERM on Windows
If the two agents of a match never write to stderr, then `Match.handleLogFiles()` tries to remove the folder.
However, this will fail on Windows because errorLogWriteStream is never closed.
Since data can still be sent by the process after close, `errorLogWriteStream` status must be checked.

## Patch for the npm packages
I don't expect this PR to be merged.
However, here is a patch for anyone in need.

```ps1
$node_modules = "$env:AppData/npm/node_modules/@lux-ai/2021-challenge/node_modules"
# $node_modules = "node_modules"
$fileA = "$node_modules/dimensions-ai/lib/main/Agent/index.js"
$AgentContents = Get-Content $fileA
# Patch EPERM, line 800
$AgentContents = $AgentContents.replace('    Agent.prototype._terminate = function () {', '    Agent.prototype._terminate = function () { this.errorLogWriteStream?.close();')
# Patch tournament timeout, line 855
$AgentContents = $AgentContents.replace('if (exists) {', 'if (!exists) resolve(); else {')
Set-Content $fileA $AgentContents

$fileME = "$node_modules/dimensions-ai/lib/main/MatchEngine/index.js"
# Patch tournament ERR_STREAM_WRITE_AFTER_END, line 280
(Get-Content $fileME).replace('    errorLogWriteStream.write("" + data);', '    if (!errorLogWriteStream.writableEnded) errorLogWriteStream.write("" + data);') | Set-Content $fileME
```